### PR TITLE
Remove service-discovery from README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -95,7 +95,7 @@ $ docker-compose up -d mysql zookeeper kafka
 ----
  * SMART COSMOS Support Mechanisms
 ----
-$ docker-compose up -d config-server service-discovery edge-user-devkit user-details-devkit auth-server events event-listener ui
+$ docker-compose up -d config-server edge-user-devkit user-details-devkit auth-server events event-listener ui
 ----
  * SMART COSMOS Core Services
 ----
@@ -136,7 +136,6 @@ smartcosmosdevkit_ext-things_1            ./entrypoint.sh /opt/smart ...   Up   
 smartcosmosdevkit_gateway_1               ./entrypoint.sh /opt/smart ...   Up      0.0.0.0:8080->8080/tcp
 smartcosmosdevkit_kafka_1                 /start.sh                        Up      7203/tcp, 0.0.0.0:9092->9092/tcp
 smartcosmosdevkit_mysql_1                 docker-entrypoint.sh mysqld      Up      3306/tcp
-smartcosmosdevkit_service-discovery_1     ./entrypoint.sh /opt/smart ...   Up      0.0.0.0:8761->8080/tcp
 smartcosmosdevkit_ui_1                    npm start                        Up      0.0.0.0:8081->3001/tcp
 smartcosmosdevkit_user-details-devkit_1   ./entrypoint.sh /opt/smart ...   Up      8080/tcp
 smartcosmosdevkit_zookeeper_1             /opt/zookeeper/bin/zkServe ...   Up      0.0.0.0:2181->2181/tcp, 2888/tcp, 3888/tcp
@@ -185,7 +184,7 @@ smartcosmosdevkit_ext-things_1            ./entrypoint.sh /opt/smart ...   Exit 
 ----
 Then a service is no longer properly running, and will need to be started separately.
 *NOTE*: The services will start dependent services as well. So `docker-compose up edge-things`
-will start `config-server`, `service-discovery`, `ext-things`, `ext-metadata` and the `auth-server`
+will start `config-server`, `ext-things`, `ext-metadata` and the `auth-server`
 (including all of their dependent services).
 
 == Start the Devkit in AWS


### PR DESCRIPTION
Removes all occurrences of `service-discovery` in the documentation.