### PR TITLE
Tutorial/objects 1145 aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /README.pdf
+
+# IntelliJ IDE
+*.ipr
+*.iml
+.idea
+

--- a/README.adoc
+++ b/README.adoc
@@ -56,7 +56,7 @@ https://documenter.getpostman.com/view/437937/smart-cosmos-objects-devkit-tutori
 
 == SMART COSMOS DevKit
 The DevKit is a composition of several standalone services which are
-communicating via REST. Each Services is running in its own container.
+communicating via REST. Each Service is running in its own container.
 To manage these service containers we are using https://docker.com[`docker`].
 
 IMPORTANT: You will need at least a basic understanding of docker for

--- a/config/smartcosmos-edge-bulkimport.yml
+++ b/config/smartcosmos-edge-bulkimport.yml
@@ -1,0 +1,11 @@
+smartcosmos:
+  edge:
+    bulk-import:
+      read-timeout: 2500
+      connect-timeout: 1500
+      thingsAddress: ${smartcosmos.service.edge-things.address}
+      relationshipsAddress: ${smartcosmos.service.ext-relationships.address}
+
+logging:
+  level:
+    ROOT: INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       CONFIG_SEARCH_LOCATIONS: file:/opt/smartcosmos/config
       ENCRYPT_KEY: 'RD@BIv2AhuFIAmKo'
     ports:
-      - "127.0.0.1:8888:8888"
+      - "8888:8888"
     networks:
       - platform-services
     volumes:
@@ -18,7 +18,7 @@ services:
   gateway:
     image: smartcosmos/gateway
     ports:
-      - "127.0.0.1:8080:8080"
+      - "8080:8080"
     depends_on:
       - config-server
     networks:
@@ -30,7 +30,7 @@ services:
     #environment:
       #SPRING_CONFIG_LOCATION: 'file:/opt/smartcosmos/config/application.yml, file:/opt/smartcosmos/config/smartcosmos-auth-server.yml'
     ports:
-      - "127.0.0.1:9999:8080"
+      - "9999:8080"
     depends_on:
       - config-server
     networks:
@@ -41,7 +41,7 @@ services:
   edge-user-devkit:
     image: smartcosmos/edge-user-devkit
     ports:
-      - "127.0.0.1:45371:8080"
+      - "45371:8080"
     depends_on:
       - config-server
       - mysql
@@ -51,7 +51,7 @@ services:
   user-details-devkit:
     image: smartcosmos/user-details-devkit
     ports:
-      - "127.0.0.1:7777:8080"
+      - "7777:8080"
     depends_on:
       - config-server
       - mysql
@@ -61,7 +61,7 @@ services:
   zookeeper:
     image: jplock/zookeeper:3.4.6
     ports:
-      - "127.0.0.1:2181:2181"
+      - "2181:2181"
     networks:
       - platform-services
 
@@ -80,7 +80,7 @@ services:
   events:
     image: smartcosmos/events
     ports:
-      - "127.0.0.1:45012:8080"
+      - "45012:8080"
     depends_on:
      - config-server
      - kafka
@@ -90,7 +90,7 @@ services:
   edge-bulkimport:
     image: smartcosmos/edge-bulkimport
     ports:
-      - "127.0.0.1:50593:8080"
+      - "50593:8080"
     depends_on:
       - config-server
     networks:
@@ -99,7 +99,7 @@ services:
   edge-things:
     image: smartcosmos/edge-things
     ports:
-      - "127.0.0.1:50594:8080"
+      - "50594:8080"
     depends_on:
       - config-server
     networks:
@@ -108,7 +108,7 @@ services:
   ext-things:
     image: smartcosmos/ext-things
     ports:
-      - "127.0.0.1:45336:8080"
+      - "45336:8080"
     depends_on:
       - config-server
       - mysql
@@ -118,7 +118,7 @@ services:
   ext-metadata:
     image: smartcosmos/ext-metadata
     ports:
-      - "127.0.0.1:45037:8080"
+      - "45037:8080"
     depends_on:
       - config-server
       - mysql
@@ -128,7 +128,7 @@ services:
   ext-relationships:
     image: smartcosmos/ext-relationships
     ports:
-      - "127.0.0.1:45369:8080"
+      - "45369:8080"
     depends_on:
       - config-server
       - mysql
@@ -138,7 +138,7 @@ services:
   mysql:
     image: mariadb:10.1.17
     ports:
-      - "127.0.0.1:3306:3306"
+      - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: devkit
@@ -146,18 +146,6 @@ services:
       MYSQL_PASSWORD: dev
     networks:
        - platform-services
-
-  ui:
-    image: smartcosmos/ui-devkit
-    ports:
-      - "127.0.0.1:8081:3001"
-    environment:
-      SERVER_PORT: 3001
-      GATEWAY_URL: http://gateway:8080
-      AUTH_URL: http://auth-server:8080
-    networks:
-      - devkit-gateway
-      - platform-services
 
 networks:
   devkit-gateway:

--- a/start
+++ b/start
@@ -122,9 +122,6 @@ function services() {
   echo -e "\n${ORANGE}→ Starting event service...${DEFAULT_COLOR}"
   start "events" 15
 
-  echo -e "\n${ORANGE}→ Starting user interface...${DEFAULT_COLOR}"
-  start "ui" 15
-
   echo -e "\n${ORANGE}→ Starting gateway...${DEFAULT_COLOR}"
   start "gateway" 15
 }

--- a/tutorials/aws/single-instance.adoc
+++ b/tutorials/aws/single-instance.adoc
@@ -1,0 +1,98 @@
+= DevKit On Single Instance in AWS
+
+This document guides you through the process of getting the SMART COSMOS DevKit
+running on an AWS instance.
+For that purpose you need to go through the following steps:
+
+. write local aws client configuration file
+. use `docker-machine` to start an instance with a docker engine
+
+If you have done these steps you can deploy the DevKit as you would on
+your local system. This is possible because the docker engine is a REST service.
+The `docker` command line client will communicate with the remote engine.
+
+[[awsConfig]]
+== Step 1. Write Local AWS Configuration
+
+
+Create an AWS credentials file at
+`$HOME/.aws/credentials`. It should contain the key_id and access_key
+of the user you want to use to create the EC2 instance. Make sure that
+user is allowed to create instances.
+[source]
+----
+[default]
+aws_access_key_id = AKID1234567890
+aws_secret_access_key = MY-SECRET-KEY
+----
+
+NOTE: This step is optional. You may also enter your AWS credentials on every
+`docker-compose` command you execute. If you want to set your credentials on the
+command line follow the
+https://docs.docker.com/machine/examples/aws/#/step-2-use-machine-to-create-the-instance[official docker documentation].
+
+== Step 2. Start A Remote AWS EC2 Instance
+
+Run `docker-machine` with the `amazonec2` driver.
+
+If you have configured your AWS credentials (as described in <<awsConfig>>) you can
+now run:
+[source, bash]
+----
+$ docker-machine create --driver amazonec2 devkit-on-aws
+----
+
+By default the instance is created in `us-east-1`.
+You can also specify the *region* by using the flag `--amazonec2-region`:
+[source, bash]
+----
+$ docker-machine create --driver amazonec2 --amazonec2-region eu-west-1 devkit-on-aws
+----
+
+There are more options for the `amazonec2` driver. Execute
+`docker-machine --driver amazonec2 --help` to get all the available options.
+
+
+Starting up the instance will take some time. It will:
+
+* create an EC2 instance
+* install Docker on the instance
+* setting up certificates for secure communication with the remote docker engine
+
+If you are getting any error consult the <<troubleshooting>> section.
+
+== Step 3. Connect Docker Command Line Tool To Remote Engine
+
+Now you need to configure that your docker command line client is using the
+newly created remote docker engine on the AWS EC2 instance:
+[source, bash]
+----
+$ eval $(docker-machine env docker-on-aws)
+----
+
+== Step 4. Start the DevKit
+If you successfully followed the previous step
+starting the DevKit does not differ from starting it on your local
+machine. Follow link:../install-devkit.adoc[the DevKit install tutorial].
+
+== Stopping/ Removing The Instance
+
+To stop the instance execute:
+[source, bash]
+----
+$ docker-machine stop devkit-on-aws
+----
+
+To permanently remove the instance run:
+[source, bash]
+----
+$ docker-machine rm devkit-on-aws
+----
+
+
+[[troubleshooting]]
+== Troubleshooting
+
+=== Error validating certificates on `docker-compose create`
+
+TODO: What to do to solve that... 😔

--- a/tutorials/getting-started.adoc
+++ b/tutorials/getting-started.adoc
@@ -9,11 +9,15 @@ Please choose the matching platform of your working machine:
 * link:prerequisites.adoc#macOS[macOS]
 * link:prerequisites.adoc#linux[GNU/Linux]
 
-=== Set Up The DevKit
+=== Set up the DevKit
 
-The start the DevKit follow the
+To start the DevKit follow the
 link:install-devkit.adoc[DevKit Set Up Guide].
 
+==== AWS
+
+If you want to set up the DevKit on a single AWS Instance follow
+link:aws/single-instance.adoc[the AWS single instance tutorial].
 
 == TODO
 Further tutorials should be listed here as well.

--- a/tutorials/install-devkit.adoc
+++ b/tutorials/install-devkit.adoc
@@ -1,36 +1,23 @@
-= Install The DevKit
+= Install the DevKit
 
 Before you are able to start the DevKit make sure you have
 link:prerequisites.adoc[installed all the prerequisites].
 
 == Get the Deploy Code
 
-[source,bash]
-----
-git clone https://github.com/SMARTRACTECHNOLOGY/smartcosmos-devkit.git
-cd smartcosmos-devkit
-----
+ $ git clone https://github.com/SMARTRACTECHNOLOGY/smartcosmos-devkit.git
+ $ cd smartcosmos-devkit
 
 [[startDevKit]]
-== Start The DevKit
+== Start the DevKit
 
 To enable you to access each service of the DevKit individually and not just
 through the `gateway` service we forward all services to a specific
-port on `127.0.0.1`. Before you start the DevKit make sure that
-you have no other application or service running that is using one of these
-ports:
+port.
 
-* 2181
-* 3306
-* 7777
-* 8080 - 8081
-* 8888
-* 9092
-* 9999
-* 45012
-* 45336 - 45037
-* 45369 - 45371
-* 50593 - 50594
+CAUTION: Before you start the DevKit ensure that
+no other application or service is listening on a
+port listed in the column *Forwarded Ports* in the link:service-ports.adoc[List of Ports] table.
 
 To start the DevKit we provide a script which will help you to get the DevKit
 up and running. You may also use `docker-compose` directly
@@ -39,10 +26,7 @@ to start all the services.
 To keep things simple we will use the start script. All you need to do is to
 execute the following:
 
-[source,bash]
-----
-./start
-----
+ $ ./start
 
 == Next Steps
 

--- a/tutorials/prerequisites.adoc
+++ b/tutorials/prerequisites.adoc
@@ -1,37 +1,53 @@
 = Prerequisites
 :imagesdir: images
+:experimental:
 
 [[macOS]]
 == macOS
 
-On macOS we highly recommend to use http://brew.sh[`brew`] to manage
+On macOS we highly recommend to use http://brew.sh[`Homebrew`] to manage
 software installations.
 
-=== Install The Tools
+=== Install the Tools
 
-==== http://brew.sh[brew]
-[source, bash]
-----
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-----
+==== http://brew.sh[Homebrew]
+
+ $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+Now you need to enable https://caskroom.github.io/[*Homebrew Cask*] by running:
+
+ $ brew tap caskroom/cask
+
+This enables brew to use the `cask` subcommand which
+allows you to install binary Applications.
 
 ==== https://git-scm.com/[git]
-[source, bash]
-----
-brew install git
-----
+
+ $ brew install git
 
 ==== https://docker.com[docker]
-[source, bash]
-----
-brew install docker
-----
+
+ $ brew cask install docker
+
+=== Start the Docker Engine
+If you installed docker the next step is to start
+the `docker-engine`. To do this hit kbd:[cmd+space] to open
+the Spotlight search, and enter
+`docker`. Start the docker Application by hitting kbd:[Enter] after
+Spotlight found the `docker` Application.
+Now follow the instructions given by the docker start
+dialog.
+
+Docker will now automatically start when you log in. If you
+prefer to start it manually you
+can disable this behavior in the docker preferences. The preferences dialog can be reached
+by clicking on the docker menu bar icon.
 
 === Check Docker Memory Settings
-Please make sure that your docker VM has at least 8GB of Memory.
+Please make sure that your docker VM has at least 5GB of Memory.
 
-In the menu bar on the top right corner should now be a docker icon. To adjust the
-memory settings you need to click on this icon:
+To adjust the
+memory settings you need to click on the docker menu bar icon:
 
 image::docker-icon-macOS.png[docker-icon]
 
@@ -39,34 +55,32 @@ Now click on `Preferences...`. You should see the following window:
 
 image::docker-pref-macOS.png[docker preferences]
 
-Here you should increase the Memory with the slider to at least 8GB.
-Please click on `Apply & Restart` to apply the settings. Finally you
+Here you should increase the Memory with the slider to at least 5GB.
+Please click on the btn:[Apply & Restart] button to
+apply the settings. Finally you
 can close the window.
 
-=== Install The DevKit
+=== Install the DevKit
 
 Please follow link:install-devkit.adoc[the DevKit install instructions].
 
 [[linux]]
 == GNU/Linux
 
-=== Install The Tools
+=== Install the Tools
 
 ==== https://git-scm.com/[git]
 Install git with the package manager. E.g. on Ubuntu with:
-[source, bash]
-----
-apt-get install git
-----
+
+ $ apt-get install git
 
 ==== https://docker.com[docker]
 Please follow
-https://docs.docker.com/engine/installation/linux/[the official installation guide ]
+https://docs.docker.com/engine/installation/linux/[the official installation guide]
 to install docker on a GNU/Linux system.
 
 Make sure that you can use docker without sudo.
 
-
-=== Install The DevKit
+=== Install the DevKit
 
 Please follow link:install-devkit.adoc[the DevKit install instructions].

--- a/tutorials/service-ports.adoc
+++ b/tutorials/service-ports.adoc
@@ -1,0 +1,27 @@
+= List of Ports
+
+[.lead]
+This document visualizes the ports used by the DevKit services. Each service
+listens on a port in its container for incoming requests. For your convenience
+all the services ports are getting forwarded to `0.0.0.0`.
+
+.Service Ports
+[cols="3", options="header"]
+|===
+| Service | Container Port | Forwarded Port
+
+| config-server | 8888 | 8888
+| gateway | 8080 | 8080
+| auth-server | 8080 | 9999
+| edge-user-devkit | 8080 |45371
+| user-details-devkit | 8080 | 7777
+| events | 8080 | 45012
+| edge-bulkimport | 8080 | 50593
+| edge-things | 8080 | 50594
+| ext-things | 8080 | 45336
+| ext-metadata | 8080 | 45037
+| ext-relationships | 8080 | 45369
+
+| zookeeper | 2181 | 2181
+| kafka | 9092 | 9092
+| mysql | 3306 | 3306


### PR DESCRIPTION
NOTE: JUST FOR REVIEW DO NOT MERGE. WORK IN PROGRESS.

This adds the tutorial on how to set up a single AWS EC2 instance with `docker-compose`.

*Please note* that this is based on #21. This should be merged after #21.