### PR TITLE
OBJECTS-1196: configure ext-things to use the MariaDB (Mysql) scripts

### DIFF
--- a/config/smartcosmos-ext-things.yml
+++ b/config/smartcosmos-ext-things.yml
@@ -4,6 +4,7 @@ server:
 flyway:
   enabled: true
   baselineOnMigrate: true
+  locations: classpath:db/migration/common, classpath:db/migration/mysql
 
 spring:
   datasource:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Configures the `ext-things` service to use the MariaDB/MySql database scripts in FlyWay

#### Depends On

[\[smartcosmos-database-devkit\] PR-5](https://github.com/SMARTRACTECHNOLOGY/smartcosmos-database-devkit/pull/5)