### PR TITLE
OBJECTS-1221: fix all services to pick up new DB script structure

### DIFF
--- a/config/smartcosmos-edge-user-devkit.yml
+++ b/config/smartcosmos-edge-user-devkit.yml
@@ -6,6 +6,7 @@ server:
 flyway:
   enabled: true
   baselineOnMigrate: true
+  locations: classpath:db/migration/common, classpath:db/migration/mysql
 
 spring:
   datasource:

--- a/config/smartcosmos-ext-metadata.yml
+++ b/config/smartcosmos-ext-metadata.yml
@@ -4,6 +4,7 @@ server:
 flyway:
   enabled: true
   baselineOnMigrate: true
+  locations: classpath:db/migration/common, classpath:db/migration/mysql
 
 spring:
   datasource:

--- a/config/smartcosmos-ext-relationships.yml
+++ b/config/smartcosmos-ext-relationships.yml
@@ -6,6 +6,7 @@ server:
 flyway:
   enabled: true
   baselineOnMigrate: true
+  locations: classpath:db/migration/common, classpath:db/migration/mysql
 
 spring:
   datasource:

--- a/config/smartcosmos-user-details-devkit.yml
+++ b/config/smartcosmos-user-details-devkit.yml
@@ -6,6 +6,7 @@ server:
 flyway:
   enabled: true
   baselineOnMigrate: false
+  locations: classpath:db/migration/common, classpath:db/migration/mysql
 
 spring:
   datasource:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the `flyway.locations` to all services that create database tables.

#### Depends On

Nothing but the following services will need to be rebuilt after this builds
`ext-things`, `ext-relationships`, `ext-metadata`, `edge-user-devkit`, `user-details-devkit`